### PR TITLE
Change error message to point to the relevant doc

### DIFF
--- a/src/main/shadow/cljs/devtools/server/repl_impl.clj
+++ b/src/main/shadow/cljs/devtools/server/repl_impl.clj
@@ -149,7 +149,7 @@
                                  runtime-id))]
 
                        (if-not runtime-id
-                         (do (repl-stderr repl-state "No available JS runtime.\nSee https://shadow-cljs.github.io/docs/UsersGuide.html#repl-troubleshooting")
+                         (do (repl-stderr repl-state "No available JS runtime.\nSee https://shadow-cljs.github.io/docs/UsersGuide.html#missing-js-runtime")
                              (repl-result repl-state nil)
                              (repl-prompt repl-state)
                              (>!! read-lock 1)


### PR DESCRIPTION
The "No available JS runtime" error uses a fragment that doesn't point to any specific part of the user guide. This fixes that.